### PR TITLE
Fixes GPII-3939: Updates to latest version of all third-party dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,19 +20,19 @@
   },
   "homepage": "https://github.com/GPII/gpii-launcher/",
   "dependencies": {
-    "infusion": "3.0.0-dev.20180227T185528Z.08741e844",
-    "kettle": "1.7.1",
-    "yargs": "11.0.0"
+    "infusion": "3.0.0-dev.20190328T144119Z.ec44dbfab",
+    "kettle": "1.10.1",
+    "yargs": "13.2.4"
   },
   "devDependencies": {
-    "eslint": "4.18.2",
-    "eslint-config-fluid": "1.2.0",
+    "eslint": "5.16.0",
+    "eslint-config-fluid": "1.3.0",
     "fluid-grunt-eslint": "18.1.2",
-    "grunt": "1.0.2",
+    "grunt": "1.0.4",
     "grunt-jsonlint": "1.1.0",
     "istanbul": "0.4.5",
     "jsonlint": "1.6.3",
     "node-jqunit": "1.1.8",
-    "rimraf": "2.6.2"
+    "rimraf": "2.6.3"
   }
 }


### PR DESCRIPTION
This PR contains updates to gpii-launcher's third-party dependencies, which have drifted a bit since it was last updated.